### PR TITLE
Fix modifying the global syntax table

### DIFF
--- a/pollen-mode.el
+++ b/pollen-mode.el
@@ -325,9 +325,9 @@ Keybindings for editing pollen file."
 
 (defvar pollen-syntax-table
   (let ((tb (make-syntax-table)))
-    (modify-syntax-entry pollen-command-char-code ". 1")
-    (modify-syntax-entry ?\; ". 2")
-    (modify-syntax-entry ?\n ">")
+    (modify-syntax-entry pollen-command-char-code ". 1" tb)
+    (modify-syntax-entry ?\; ". 2" tb)
+    (modify-syntax-entry ?\n ">" tb)
     tb))
 
 ;;;###autoload


### PR DESCRIPTION
This commit fixes modifying syntax entries to the standard global syntax
table.  The previous situation, modifications to the global syntax
table, broke other modes, such as org-mode when tangling with command
org-babel-tangle.  It also changed the meaning of command
isearch-forward-regexp with regular expression '\s-' or '\S-'.  This fix
modifies the syntax entries on the created syntax table.