### PR TITLE
Add autoloads to minor mode and server commands

### DIFF
--- a/pollen-mode.el
+++ b/pollen-mode.el
@@ -268,6 +268,7 @@ of that block. Feel free to change the new buffer's mode."
 (defconst pollen-minor-mode-indicator
   (concat " " pollen-command-char-target "/" pollen-command-char))
 
+;;;###autoload
 (define-minor-mode pollen-minor-mode
   "pollen minor mode.
 
@@ -384,6 +385,7 @@ Keybindings for editing pollen file."
   "This variable caches project root directory.  It is set when
   `pollen-server-start' is called.")
 
+;;;###autoload
 (defun pollen-server-start (root-dir)
   "Start pollen server at the given ROOT-DIR.
 


### PR DESCRIPTION
Sometimes when I start editing a new Pollen project, I'll work on the template first, which would ideally be in `web-mode` + `pollen-minor-mode`. However, as `pollen-minor-mode` isn't autoloaded, I'd have to `M-: (require 'pollen-mode)` manually before being able to use it. The story is similar with `pollen-server-start`: it'd be nice to be able to start the server without first having visited a `.pm` file.

Adding autoload cookies on `pollen-minor-mode` and `pollen-server-start` fixes this.